### PR TITLE
Changes required for building on the Pi 4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ These scripts install the necessary tools to compile libgrpc_csharp_ext.
 1. mkdir ~/libgrpc_csharp_ext (or whatever root directory you want)
 2. cd ~/libgrpc_csharp_ext
 2. git clone https://github.com/erikest/libgrpc_csharp_ext
-3. chmod +x installToolChain.sh
-4. sudo ./installToolChain.sh
+3. chmod +x installToolchain.sh
+4. sudo ./installToolchain.sh
 5. chmod +x gitgRPCsource.sh
 6. ./gitgRPCsource.sh
-7. chmod +x compile_csharp_ext.sh
-8. ./compile_csharp_ext.sh
+7. Add the following to the first line of CMakeLists.txt located in grpc:
+	add_link_options(-latomic)
+8. chmod +x compile_csharp_ext.sh
+9. ./compile_csharp_ext.sh
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ These scripts install the necessary tools to compile libgrpc_csharp_ext.
 3. chmod +x installToolchain.sh
 4. sudo ./installToolchain.sh
 5. chmod +x gitgRPCsource.sh
-6. ./gitgRPCsource.sh
-7. Add the following to the first line of CMakeLists.txt located in grpc:
+6. Run the following command to clone the grpc repo at v1.36.4 (you may wish to edit this script to get the latest version):
+ 	./gitgRPCsource.sh
+8. Add the following to the first line of CMakeLists.txt located in grpc:
 	add_link_options(-latomic)
 8. chmod +x compile_csharp_ext.sh
 9. ./compile_csharp_ext.sh

--- a/gitgRPCsource.sh
+++ b/gitgRPCsource.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+git clone -b v1.36.4 https://github.com/grpc/grpc
 cd grpc
 git submodule update --init


### PR DESCRIPTION
Addresses issues #2 and #3 with the side affect that scripts will build v1.36.4 of grpc unless a modification is made to ./gitgRPCsource.sh prior to running. This fixed the "undefined symbol: __atomic_load_8" error on my Pi 4.